### PR TITLE
Fix broken encoding conversion after buffer resize

### DIFF
--- a/ext/wmq_queue.c
+++ b/ext/wmq_queue.c
@@ -772,20 +772,14 @@ VALUE Queue_get(VALUE self, VALUE hash)
               &pq->comp_code,      /* completion code                   */
               &pq->reason_code);   /* reason code                       */
 
-        /* report reason, if any     */
-        if (pq->reason_code != MQRC_NONE)
+        if (pq->reason_code == MQRC_TRUNCATED_MSG_FAILED)
         {
-            if(pq->trace_level>1) printf("WMQ::Queue#get() Growing buffer size from %ld to %ld\n", (long)pq->buffer_size, (long)messlen);
-            /* TODO: Add support for autogrow buffer here */
-            if (pq->reason_code == MQRC_TRUNCATED_MSG_FAILED)
-            {
-                if(pq->trace_level>2)
-                    printf ("WMQ::Queue#reallocate Resizing buffer from %ld to %ld bytes\n", (long)pq->buffer_size, (long)messlen);
+            if(pq->trace_level>2)
+                printf ("WMQ::Queue#reallocate Resizing buffer from %ld to %ld bytes\n", (long)pq->buffer_size, (long)messlen);
 
-                free(pq->p_buffer);
-                pq->buffer_size = messlen;
-                pq->p_buffer = ALLOC_N(unsigned char, messlen);
-            }
+            free(pq->p_buffer);
+            pq->buffer_size = messlen;
+            pq->p_buffer = ALLOC_N(unsigned char, messlen);
         }
     }
     while (pq->reason_code == MQRC_TRUNCATED_MSG_FAILED);

--- a/ext/wmq_queue.c
+++ b/ext/wmq_queue.c
@@ -792,7 +792,7 @@ VALUE Queue_get(VALUE self, VALUE hash)
 
     if(pq->trace_level) printf("WMQ::Queue#get() MQGET ended with reason:%s\n", wmq_reason(pq->reason_code));
 
-    if (pq->comp_code != MQCC_FAILED)
+    if (pq->comp_code == MQCC_OK)
     {
         /*
          * Sanity check that the message is in the expected encoding, otherwise decoding will fail with errors due to

--- a/ext/wmq_queue.c
+++ b/ext/wmq_queue.c
@@ -794,6 +794,17 @@ VALUE Queue_get(VALUE self, VALUE hash)
 
     if (pq->comp_code != MQCC_FAILED)
     {
+        /*
+         * Sanity check that the message is in the expected encoding, otherwise decoding will fail with errors due to
+         * mismatched number formats.
+         */
+        if (md.Encoding != MQENC_NATIVE) {
+            rb_raise(wmq_exception,
+                     "WMQ::Queue#get(). Received message in unexpected encoding. Native encoding: %i, received encoding: %i",
+                     MQENC_NATIVE,
+                     md.Encoding);
+        }
+
         Message_deblock(message, &md, pq->p_buffer, messlen, pq->trace_level);  /* Extract MQMD and any other known MQ headers */
         return Qtrue;
     }


### PR DESCRIPTION
Reinitialize message descriptor (MQMD) if we're retrying after a buffer resize.

Some of the MQMD fields, like `Encoding` are both input AND output fields. If the request fails due to `MQRC_TRUNCATED_MSG_FAILED`, the conversion won't happen and `md.Encoding` will be set to the pre-conversion encoding. If we re-send the same `md` value, we end up requesting that encoding instead of the native encoding we wanted.