### PR TITLE
Add certificate_label option for SSL

### DIFF
--- a/lib/wmq/queue_manager.rb
+++ b/lib/wmq/queue_manager.rb
@@ -40,6 +40,7 @@ module WMQ
     #   # SSL Options
     #   key_repository:      '/var/mqm/qmgrs/.../key',        # MQSCO.KeyRepository
     #   crypto_hardware:     'GSK_ACCELERATOR_NCIPHER_NF_ON', # MQSCO.CryptoHardware
+    #   certificate_label:   'myclientcert',                  # MQSCO.CertificateLabel
     #   )
     #
     # Optional Parameters


### PR DESCRIPTION
* Expose MQSCO.CertificateLabel field to Ruby
* Make sure we're declaring the current version on all structs, otherwise fields like CertificateLabel and SSLCipherSpec are ignored.